### PR TITLE
Fix VPC model is_default requires

### DIFF
--- a/lib/fog/aws/models/compute/vpc.rb
+++ b/lib/fog/aws/models/compute/vpc.rb
@@ -39,7 +39,7 @@ module Fog
         end
 
         def is_default?
-          require :is_default
+          requires :is_default
           is_default
         end
 


### PR DESCRIPTION
`is_default?` requires attribute `IsDefault` to be defined. This is different to requiring ruby code with `Kernel#require`